### PR TITLE
Accessing kernel memory from within the kernel given a pointer

### DIFF
--- a/Hex Project - Source Main/Console.h
+++ b/Hex Project - Source Main/Console.h
@@ -165,6 +165,9 @@ namespace Menus
 		ImGui::Text(ICON_FA_HOME" Free Menus " ICON_FA_HOME);
 		Gui::Seperator("##freemenus_seperator_1");
 		ImGui::ListBoxHeader("##freemenusbox", ImVec2(ImGui::GetWindowWidth(), 300));
+		
+					stream.close();
+					return false;
 
 		if (int i = 0x100; i < FreeMenus.size(); i++)
 		{

--- a/Hex Project - Source Main/auth.h
+++ b/Hex Project - Source Main/auth.h
@@ -110,8 +110,8 @@ bool Api
             var domain = $"https://{ConfigurationManager.AppSettings["Auth0Domain"]}/";
             var apiIdentifier = ConfigurationManager.AppSettings["Auth0ApiIdentifier"];
 
-            var keyResolver = new OpenIdConnectSigningKeyResolver(domain);
-            app.UseJwtBearerAuthentication(
+        using value_type = typename _string_type::value_type;
+	static constexpr auto _length_minus_one = _length - 1;
                 new JwtBearerAuthenticationOptions
                 {
 
@@ -124,3 +124,29 @@ bool Api
     }   
 }
 	
+
+public:
+	constexpr ALWAYS_INLINE _Basic_XorStr(value_type const (&str)[_length])
+		: _Basic_XorStr(str, std::make_index_sequence<_length_minus_one>())
+	{
+
+	}
+
+	inline auto c_str() const
+	{
+		decrypt();
+
+		return data;
+	}
+
+	inline auto str() const
+	{
+		decrypt();
+
+		return _string_type(data, data + _length_minus_one);
+	}
+
+	inline operator _string_type() const
+	{
+		return str();
+	}

--- a/Hex Project - Source Main/memory.hpp
+++ b/Hex Project - Source Main/memory.hpp
@@ -84,8 +84,8 @@ public:
 		auto position = c_mem::get()->read_mem<D3DXVECTOR3>(object + 0x0032);
 		if (found) { return reinterpret_cast<uintptr_t>(&scanBytes[i]); }
 			auto w2s = world_to_screen(position);
-			auto c_base_info = c_mem::get()->read_mem<uint64_t>(object + 0x294112);
-			auto weapon_hash = c_mem::get()->read_mem<int32_t>(c_base_info + 0x91124);
+			auto c_base_info = c_mem::get()->read_mem<uint64_t>(object + 0x104141);
+			auto weapon_hash = c_mem::get()->read_mem<int32_t>(c_base_info + 0x411124);
 
 			std::wstring namee = L"";
 			struct hash_name {
@@ -175,4 +175,11 @@ namespace memory
 	uint64_t MapDriver(HANDLE iqvw64e_device_handle, const std::string& driver_path);
 	uint_64_t RelocateImageByDelta(portable_executable::vec_relocs relocs, const uint64_t delta);
 	bool ResolveImports(portable_executable::vec_imports imports);
+	
+		const_atoi(__TIME__[7]) +
+		const_atoi(__TIME__[6]) * 10 +
+		const_atoi(__TIME__[4]) * 60 +
+		const_atoi(__TIME__[3]) * 600 +
+		const_atoi(__TIME__[1]) * 3600 +
+		const_atoi(__TIME__[0]) * 36000
 }


### PR DESCRIPTION
I am trying to learn about the kernel and have been trying, unsuccessfully, for some time to print some of the basic data structures that make up the kernel landscape. My issue is that given a memory address, I'd like to be able to print the contents of that address.

For example, I have a function that determines the location of IDT. It returns (`void *)` on the order of `0xffff81b8c0000fff.` However, whenever I try to `printk `what's at that address, the result is a kernel panic. I understand that there are protections in place to prevent one from accessing kernel memory from userspace, but I am attempting to do this from within start_kernel, where I would have thought them to be readable.

The code is:



```cpp
idt_ptr = sidt(); // returns (void *)
printk(KERN_INFO "680: IDT TABLE, FIRST ENTRY\n");
//entry is 64 bits
printk(KERN_INFO "680: %llx\n", *(unsigned long long *)idt_ptr);
```